### PR TITLE
Changed back to good code style since CORS is now disabled for heroku origin

### DIFF
--- a/src/main/java/com/heroku/backend/config/MongoDBConfig.java
+++ b/src/main/java/com/heroku/backend/config/MongoDBConfig.java
@@ -1,4 +1,4 @@
-package com.heroku.backend;
+package com.heroku.backend.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -8,7 +8,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
 
 @Configuration
-public class MongoDBConfiguration {
+public class MongoDBConfig {
 
     @Value("${mongodb.uri}")
     private String mongoDbUri;

--- a/src/main/java/com/heroku/backend/config/ValueConfig.java
+++ b/src/main/java/com/heroku/backend/config/ValueConfig.java
@@ -1,10 +1,10 @@
-package com.heroku.backend;
+package com.heroku.backend.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class ValueConfiguration {
+public class ValueConfig {
 
     public static String mongoDbUri;
     public static String authenticationToken;
@@ -13,22 +13,22 @@ public class ValueConfiguration {
 
     @Value("${mongodb.uri}")
     public void setMongoDbUri(String mongoDbUri) {
-        ValueConfiguration.mongoDbUri = mongoDbUri;
+        ValueConfig.mongoDbUri = mongoDbUri;
     }
 
     @Value("${authentication.user}")
     public void setAuthenticationToken(String authenticationToken) {
-        ValueConfiguration.authenticationToken = authenticationToken;
+        ValueConfig.authenticationToken = authenticationToken;
     }
 
     @Value("${users.jan.base64}")
     public void setBase64FirstUser(String base64FirstUser) {
-        ValueConfiguration.base64FirstUser = base64FirstUser;
+        ValueConfig.base64FirstUser = base64FirstUser;
     }
 
     @Value("${users.lea.base64}")
     public void setBase64SecondUser(String base64SecondUser) {
-        ValueConfiguration.base64SecondUser = base64SecondUser;
+        ValueConfig.base64SecondUser = base64SecondUser;
     }
 
 }

--- a/src/main/java/com/heroku/backend/config/WebSecurityConfig.java
+++ b/src/main/java/com/heroku/backend/config/WebSecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.web.cors.CorsConfiguration;
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.cors().configurationSource(request -> new CorsConfiguration().applyPermitDefaultValues());
+        http
+                .cors().configurationSource(request -> new CorsConfiguration().applyPermitDefaultValues())
+                .and().csrf().disable();
     }
 }

--- a/src/main/java/com/heroku/backend/config/WebSecurityConfig.java
+++ b/src/main/java/com/heroku/backend/config/WebSecurityConfig.java
@@ -1,28 +1,14 @@
 package com.heroku.backend.config;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @EnableWebSecurity
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.cors().configurationSource(request -> new CorsConfiguration().applyPermitDefaultValues());
-    }
-
-    @Bean
-    CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration corsConfiguration = new CorsConfiguration();
-        corsConfiguration.addAllowedOrigin("https://haushaltsplan.herokuapp.com/");
-        corsConfiguration.addAllowedHeader("*");
-        corsConfiguration.addAllowedMethod("*");
-        UrlBasedCorsConfigurationSource urlBasedCorsConfigurationSource = new UrlBasedCorsConfigurationSource();
-        urlBasedCorsConfigurationSource.registerCorsConfiguration("/**", corsConfiguration);
-        return urlBasedCorsConfigurationSource;
     }
 }

--- a/src/main/java/com/heroku/backend/controller/AuthTokenController.java
+++ b/src/main/java/com/heroku/backend/controller/AuthTokenController.java
@@ -4,7 +4,7 @@ import com.heroku.backend.exception.InvalidBase64StringException;
 import com.heroku.backend.service.AuthTokenService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,7 +17,7 @@ public class AuthTokenController {
     }
 
     @GetMapping("/getAuthToken")
-    public ResponseEntity<String> getAuthToken(@RequestParam("auth") String base64String)
+    public ResponseEntity<String> getAuthToken(@RequestHeader("Auth-String") String base64String)
             throws InvalidBase64StringException {
         return authTokenService.getAuthToken(base64String);
     }

--- a/src/main/java/com/heroku/backend/controller/LoginController.java
+++ b/src/main/java/com/heroku/backend/controller/LoginController.java
@@ -2,9 +2,8 @@ package com.heroku.backend.controller;
 
 import com.heroku.backend.service.LoginService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -16,7 +15,7 @@ public class LoginController {
     }
 
     @GetMapping("/login")
-    public ResponseEntity<Boolean> loginUser(@RequestParam("auth") String base64String) {
+    public ResponseEntity<Boolean> loginUser(@RequestHeader("Auth-String") String base64String) {
         return loginService.loginUser(base64String);
     }
 }

--- a/src/main/java/com/heroku/backend/controller/TaskController.java
+++ b/src/main/java/com/heroku/backend/controller/TaskController.java
@@ -17,36 +17,26 @@ public class TaskController {
     }
 
     @GetMapping("/getDocuments")
-    public ResponseEntity<List<TaskEntity>> getDocuments(@RequestParam("token") String authToken) throws InvalidAuthenticationTokenException {
+    public ResponseEntity<List<TaskEntity>> getDocuments(@RequestHeader("Auth-Token") String authToken)
+            throws InvalidAuthenticationTokenException {
         return taskService.getDocuments(authToken);
     }
 
-    @GetMapping("/addDocument")
-    public ResponseEntity<String> addDocument(@RequestParam("day") String day,
-                                              @RequestParam("chore") String chore,
-                                              @RequestParam("pic") String pic,
-                                              @RequestParam("blame") String blame,
-                                              @RequestParam("done") boolean done,
-                                              @RequestParam("token") String authToken) throws InvalidAuthenticationTokenException {
-        TaskEntity taskEntity = new TaskEntity(day, chore, pic, blame, done);
+    @PostMapping("/addDocument")
+    public ResponseEntity<String> addDocument(@RequestBody TaskEntity taskEntity, @RequestHeader("Auth-Token") String authToken)
+            throws InvalidAuthenticationTokenException {
         return taskService.addDocument(taskEntity, authToken);
     }
 
-    @GetMapping("/updateDocument")
-    public ResponseEntity<String> updateDocument(@RequestParam("id") String id,
-                                                 @RequestParam("day") String day,
-                                                 @RequestParam("chore") String chore,
-                                                 @RequestParam("pic") String pic,
-                                                 @RequestParam("blame") String blame,
-                                                 @RequestParam("done") boolean done,
-                                                 @RequestParam("token") String authToken) throws InvalidAuthenticationTokenException {
-        TaskEntity taskEntity = new TaskEntity(id, day, chore, pic, blame, done);
+    @PutMapping("/updateDocument")
+    public ResponseEntity<String> updateDocument(@RequestBody TaskEntity taskEntity, @RequestHeader("Auth-Token") String authToken)
+            throws InvalidAuthenticationTokenException {
         return taskService.updateDocument(taskEntity, authToken);
     }
 
-    @GetMapping("/deleteDocument")
-    public ResponseEntity<String> deleteDocument(@RequestParam("id") String id,
-                                                 @RequestParam("token") String authToken) throws InvalidAuthenticationTokenException {
+    @DeleteMapping("/deleteDocument")
+    public ResponseEntity<String> deleteDocument(@RequestParam("id") String id, @RequestHeader("Auth-Token") String authToken)
+            throws InvalidAuthenticationTokenException {
         return taskService.deleteDocument(id, authToken);
     }
 }

--- a/src/main/java/com/heroku/backend/service/AuthTokenService.java
+++ b/src/main/java/com/heroku/backend/service/AuthTokenService.java
@@ -1,6 +1,6 @@
 package com.heroku.backend.service;
 
-import com.heroku.backend.ValueConfiguration;
+import com.heroku.backend.config.ValueConfig;
 import com.heroku.backend.exception.InvalidBase64StringException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -9,9 +9,9 @@ import org.springframework.stereotype.Service;
 public class AuthTokenService {
 
     public ResponseEntity<String> getAuthToken(String base64String) throws InvalidBase64StringException {
-        if (base64String.equals(ValueConfiguration.base64FirstUser) ||
-                base64String.equals(ValueConfiguration.base64SecondUser)) {
-            return ResponseEntity.ok(ValueConfiguration.authenticationToken);
+        if (base64String.equals(ValueConfig.base64FirstUser) ||
+                base64String.equals(ValueConfig.base64SecondUser)) {
+            return ResponseEntity.ok(ValueConfig.authenticationToken);
         }
 
         throw new InvalidBase64StringException();

--- a/src/main/java/com/heroku/backend/service/LoginService.java
+++ b/src/main/java/com/heroku/backend/service/LoginService.java
@@ -1,6 +1,6 @@
 package com.heroku.backend.service;
 
-import com.heroku.backend.ValueConfiguration;
+import com.heroku.backend.config.ValueConfig;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Service;
 public class LoginService {
 
     public ResponseEntity<Boolean> loginUser(String base64String) {
-        if (base64String.equals(ValueConfiguration.base64FirstUser) ||
-                base64String.equals(ValueConfiguration.base64SecondUser)) {
+        if (base64String.equals(ValueConfig.base64FirstUser) ||
+                base64String.equals(ValueConfig.base64SecondUser)) {
             return ResponseEntity.ok(true);
         }
 

--- a/src/main/java/com/heroku/backend/service/TaskService.java
+++ b/src/main/java/com/heroku/backend/service/TaskService.java
@@ -1,12 +1,11 @@
 package com.heroku.backend.service;
 
-import com.heroku.backend.MongoDBConfiguration;
-import com.heroku.backend.ValueConfiguration;
+import com.heroku.backend.config.MongoDBConfig;
+import com.heroku.backend.config.ValueConfig;
 import com.heroku.backend.entity.TaskEntity;
 import com.heroku.backend.exception.InvalidAuthenticationTokenException;
 import com.heroku.backend.repository.TaskRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.data.mongodb.core.MongoOperations;
@@ -26,12 +25,12 @@ public class TaskService {
     @Autowired
     public TaskService(TaskRepository taskRepository) {
         this.taskRepository = taskRepository;
-        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(MongoDBConfiguration.class);
+        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(MongoDBConfig.class);
         mongoOperations = (MongoOperations) applicationContext.getBean("mongoTemplate");
     }
 
     public ResponseEntity<List<TaskEntity>> getDocuments(String authToken) throws InvalidAuthenticationTokenException {
-        if (!authToken.equals(ValueConfiguration.authenticationToken)) {
+        if (!authToken.equals(ValueConfig.authenticationToken)) {
             throw new InvalidAuthenticationTokenException();
         }
 
@@ -39,7 +38,7 @@ public class TaskService {
     }
 
     public ResponseEntity<String> addDocument(TaskEntity taskEntity, String authToken) throws InvalidAuthenticationTokenException {
-        if (!authToken.equals(ValueConfiguration.authenticationToken)) {
+        if (!authToken.equals(ValueConfig.authenticationToken)) {
             throw new InvalidAuthenticationTokenException();
         }
 
@@ -63,7 +62,7 @@ public class TaskService {
     }
 
     public ResponseEntity<String> updateDocument(TaskEntity taskEntity, String authToken) throws InvalidAuthenticationTokenException {
-        if (!authToken.equals(ValueConfiguration.authenticationToken)) {
+        if (!authToken.equals(ValueConfig.authenticationToken)) {
             throw new InvalidAuthenticationTokenException();
         }
 
@@ -91,7 +90,7 @@ public class TaskService {
     }
 
     public ResponseEntity<String> deleteDocument(String id, String authToken) throws InvalidAuthenticationTokenException {
-        if (!authToken.equals(ValueConfiguration.authenticationToken)) {
+        if (!authToken.equals(ValueConfig.authenticationToken)) {
             throw new InvalidAuthenticationTokenException();
         }
 


### PR DESCRIPTION
I managed to disable CORS with SpringSecurity so I now don't have to use a proxy service anymore.
This is why I changed back some features to meet good code standards again. I needed to write some ugly code to workaround [this CORS issue](https://github.com/janetschel/haushaltsplan/issues/5).

This is the code that fixed the issue:

<img width="749" alt="Bildschirmfoto 2020-04-07 um 10 38 29" src="https://user-images.githubusercontent.com/46886724/78648179-eede8780-78bb-11ea-99a6-d94965d1c860.png">

Note that I needed to disable csrf as well to enable POST, PUT and DELETE requests again with the way I implemented my login page in the frontend. This doesn't matter from a security standpoint thought since the users need to authenticate every request with a custom request header which renders csrf useless for any attackers anyway.