### PR TITLE
Rejecting requests if too many are made

### DIFF
--- a/src/main/java/de/janetschel/haushaltsplan/backend/controller/LoginController.java
+++ b/src/main/java/de/janetschel/haushaltsplan/backend/controller/LoginController.java
@@ -1,5 +1,6 @@
 package de.janetschel.haushaltsplan.backend.controller;
 
+import de.janetschel.haushaltsplan.backend.exception.TooManyRequestsException;
 import de.janetschel.haushaltsplan.backend.service.LoginService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,7 +16,7 @@ public class LoginController {
     }
 
     @GetMapping("/login")
-    public ResponseEntity<Boolean> loginUser(@RequestHeader("Auth-String") String base64String) {
+    public ResponseEntity<Boolean> loginUser(@RequestHeader("Auth-String") String base64String) throws TooManyRequestsException {
         return loginService.loginUser(base64String);
     }
 }

--- a/src/main/java/de/janetschel/haushaltsplan/backend/exception/TooManyRequestsException.java
+++ b/src/main/java/de/janetschel/haushaltsplan/backend/exception/TooManyRequestsException.java
@@ -1,0 +1,11 @@
+package de.janetschel.haushaltsplan.backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.TOO_MANY_REQUESTS, reason = "Request rejected")
+public class TooManyRequestsException extends Exception {
+    public TooManyRequestsException() {
+        super();
+    }
+}

--- a/src/main/java/de/janetschel/haushaltsplan/backend/service/LoginService.java
+++ b/src/main/java/de/janetschel/haushaltsplan/backend/service/LoginService.java
@@ -1,19 +1,35 @@
 package de.janetschel.haushaltsplan.backend.service;
 
 import de.janetschel.haushaltsplan.backend.config.ValueConfig;
+import de.janetschel.haushaltsplan.backend.exception.TooManyRequestsException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 @Service
+@EnableScheduling
 public class LoginService {
 
-    public ResponseEntity<Boolean> loginUser(String base64String) {
+    private static int attempts = 0;
+
+    public ResponseEntity<Boolean> loginUser(String base64String) throws TooManyRequestsException {
+        if (++attempts >= 10) {
+            throw new TooManyRequestsException();
+        }
+
         if (base64String.equals(ValueConfig.base64FirstUser) ||
                 base64String.equals(ValueConfig.base64SecondUser)) {
             return ResponseEntity.ok(true);
         }
 
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(false);
+    }
+
+    @Scheduled(cron = "*/20 * * * * *")
+    private void resetAttempts() {
+        attempts = 0;
     }
 }

--- a/src/main/java/de/janetschel/haushaltsplan/backend/service/LoginService.java
+++ b/src/main/java/de/janetschel/haushaltsplan/backend/service/LoginService.java
@@ -1,10 +1,12 @@
 package de.janetschel.haushaltsplan.backend.service;
 
+import de.janetschel.haushaltsplan.backend.App;
 import de.janetschel.haushaltsplan.backend.config.ValueConfig;
 import de.janetschel.haushaltsplan.backend.exception.TooManyRequestsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Service;
 @Service
 @EnableScheduling
 public class LoginService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoginService.class);
 
     private static int attempts = 0;
 
@@ -30,6 +33,14 @@ public class LoginService {
 
     @Scheduled(cron = "*/20 * * * * *")
     private void resetAttempts() {
+        LOGGER.info("Reset attempts for login. Accepting all requests now.");
+
+        if (attempts >= 10) {
+            LOGGER.warn(attempts + " attempts made since the last reset.");
+        } else {
+            LOGGER.info(attempts + " attempts made since the last reset. No indication of any attacks.");
+        }
+
         attempts = 0;
     }
 }


### PR DESCRIPTION
If more than 9 login requests are made in a time span of 20 seconds (more than enough clearence for at most 2 users) the server response with 429 instead of checking the credentials and responding with a 403/200. This is an extra step to protect against brute force attacks