### PR TITLE
Feedback can now be added to a document when completed

### DIFF
--- a/src/main/java/de/janetschel/haushaltsplan/backend/controller/TaskController.java
+++ b/src/main/java/de/janetschel/haushaltsplan/backend/controller/TaskController.java
@@ -1,6 +1,7 @@
 package de.janetschel.haushaltsplan.backend.controller;
 
 import de.janetschel.haushaltsplan.backend.entity.TaskEntity;
+import de.janetschel.haushaltsplan.backend.enums.Feedback;
 import de.janetschel.haushaltsplan.backend.exception.InvalidAuthenticationTokenException;
 import de.janetschel.haushaltsplan.backend.service.TaskService;
 import org.springframework.http.ResponseEntity;
@@ -36,7 +37,7 @@ public class TaskController {
 
     @PutMapping("/updateDocument/addFeedback/{id}")
     public ResponseEntity<String> addFeedbackToDocument(@PathVariable("id") String id,
-                                                        @RequestParam("feedback") int feedback,
+                                                        @RequestParam("feedback") Feedback feedback,
                                                         @RequestHeader("Auth-Token") String authToken)
             throws InvalidAuthenticationTokenException{
         return taskService.addFeedbackToDocument(id, feedback, authToken);

--- a/src/main/java/de/janetschel/haushaltsplan/backend/controller/TaskController.java
+++ b/src/main/java/de/janetschel/haushaltsplan/backend/controller/TaskController.java
@@ -34,6 +34,14 @@ public class TaskController {
         return taskService.updateDocument(taskEntity, authToken);
     }
 
+    @PutMapping("/updateDocument/addFeedback/{id}")
+    public ResponseEntity<String> addFeedbackToDocument(@PathVariable("id") String id,
+                                                        @RequestParam("feedback") int feedback,
+                                                        @RequestHeader("Auth-Token") String authToken)
+            throws InvalidAuthenticationTokenException{
+        return taskService.addFeedbackToDocument(id, feedback, authToken);
+    }
+
     @DeleteMapping("/deleteDocument")
     public ResponseEntity<String> deleteDocument(@RequestParam("id") String id, @RequestHeader("Auth-Token") String authToken)
             throws InvalidAuthenticationTokenException {

--- a/src/main/java/de/janetschel/haushaltsplan/backend/controller/TaskController.java
+++ b/src/main/java/de/janetschel/haushaltsplan/backend/controller/TaskController.java
@@ -36,8 +36,8 @@ public class TaskController {
     }
 
     @PutMapping("/updateDocument/addFeedback/{id}")
-    public ResponseEntity<String> addFeedbackToDocument(@PathVariable("id") String id,
-                                                        @RequestParam("feedback") Feedback feedback,
+    public ResponseEntity<String> addFeedbackToDocument(@RequestParam("feedback") Feedback feedback,
+                                                        @PathVariable("id") String id,
                                                         @RequestHeader("Auth-Token") String authToken)
             throws InvalidAuthenticationTokenException{
         return taskService.addFeedbackToDocument(id, feedback, authToken);

--- a/src/main/java/de/janetschel/haushaltsplan/backend/entity/TaskEntity.java
+++ b/src/main/java/de/janetschel/haushaltsplan/backend/entity/TaskEntity.java
@@ -22,6 +22,7 @@ public class TaskEntity {
     private String pic;
     private String blame;
     private boolean done;
+    private int feedback;
 
     public TaskEntity(String day, String chore, String pic, String blame, boolean done) {
         this.day = day;
@@ -29,5 +30,6 @@ public class TaskEntity {
         this.pic = pic;
         this.blame = blame;
         this.done = done;
+        this.feedback = -1;
     }
 }

--- a/src/main/java/de/janetschel/haushaltsplan/backend/entity/TaskEntity.java
+++ b/src/main/java/de/janetschel/haushaltsplan/backend/entity/TaskEntity.java
@@ -1,5 +1,6 @@
 package de.janetschel.haushaltsplan.backend.entity;
 
+import de.janetschel.haushaltsplan.backend.enums.Feedback;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -22,7 +23,7 @@ public class TaskEntity {
     private String pic;
     private String blame;
     private boolean done;
-    private int feedback;
+    private Feedback feedback = Feedback.NO_FEEDBACK_GIVEN;
 
     public TaskEntity(String day, String chore, String pic, String blame, boolean done) {
         this.day = day;
@@ -30,6 +31,5 @@ public class TaskEntity {
         this.pic = pic;
         this.blame = blame;
         this.done = done;
-        this.feedback = -1;
     }
 }

--- a/src/main/java/de/janetschel/haushaltsplan/backend/enums/Feedback.java
+++ b/src/main/java/de/janetschel/haushaltsplan/backend/enums/Feedback.java
@@ -1,0 +1,17 @@
+package de.janetschel.haushaltsplan.backend.enums;
+
+import lombok.Getter;
+
+public enum Feedback {
+    NO_FEEDBACK_GIVEN("NO_FEEDBACK_GIVEN"),
+    GOOD("GOOD"),
+    OKAY("OKAY"),
+    BAD("BAD");
+
+    @Getter
+    private final String value;
+
+    Feedback(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/de/janetschel/haushaltsplan/backend/service/LoginService.java
+++ b/src/main/java/de/janetschel/haushaltsplan/backend/service/LoginService.java
@@ -1,6 +1,5 @@
 package de.janetschel.haushaltsplan.backend.service;
 
-import de.janetschel.haushaltsplan.backend.App;
 import de.janetschel.haushaltsplan.backend.config.ValueConfig;
 import de.janetschel.haushaltsplan.backend.exception.TooManyRequestsException;
 import org.slf4j.Logger;

--- a/src/main/java/de/janetschel/haushaltsplan/backend/service/TaskService.java
+++ b/src/main/java/de/janetschel/haushaltsplan/backend/service/TaskService.java
@@ -1,6 +1,7 @@
 package de.janetschel.haushaltsplan.backend.service;
 
 import de.janetschel.haushaltsplan.backend.entity.TaskEntity;
+import de.janetschel.haushaltsplan.backend.enums.Feedback;
 import de.janetschel.haushaltsplan.backend.exception.InvalidAuthenticationTokenException;
 import de.janetschel.haushaltsplan.backend.repository.TaskRepository;
 import org.springframework.beans.factory.annotation.Value;
@@ -80,30 +81,22 @@ public class TaskService {
         return ResponseEntity.ok(message);
     }
 
-    public ResponseEntity<String> addFeedbackToDocument(String id, int feedback, String authToken)
+    public ResponseEntity<String> addFeedbackToDocument(String id, Feedback feedback, String authToken)
             throws InvalidAuthenticationTokenException {
         if (!authToken.equals(authtoken)) {
             throw new InvalidAuthenticationTokenException();
         }
 
-        String message = "Could not add feedback to task. Reason: Feedback must be a number between 0 and 10 inclusive";
-
-        if (feedback < 0 || feedback > 10) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(message);
-        }
-
-        message = "Could not add feedback to task. Reason: Task with ID '" + id + "' does not exist";
-
         TaskEntity documentToAddFeedback = taskRepository.findById(id).orElse(null);
 
         if (documentToAddFeedback == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(message);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body("Could not add feedback to task. Reason: Task with ID '" + id + "' does not exist");
         }
 
-        message = "Could not add feedback to task. Reason: Task with ID '" + id + "' is not completed yet";
-
         if (!documentToAddFeedback.isDone()) {
-            return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).body(message);
+            return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE)
+                    .body("Could not add feedback to task. Reason: Task with ID '" + id + "' is not completed yet");
         }
 
         documentToAddFeedback.setFeedback(feedback);
@@ -111,8 +104,7 @@ public class TaskService {
         taskRepository.deleteById(id);
         taskRepository.save(documentToAddFeedback);
 
-        message = "Feedback successfully added to task";
-        return ResponseEntity.ok(message);
+        return ResponseEntity.ok("Feedback successfully added to task");
     }
 
     public ResponseEntity<String> deleteDocument(String id, String authToken) throws InvalidAuthenticationTokenException {

--- a/src/main/java/de/janetschel/haushaltsplan/backend/service/TaskService.java
+++ b/src/main/java/de/janetschel/haushaltsplan/backend/service/TaskService.java
@@ -80,6 +80,41 @@ public class TaskService {
         return ResponseEntity.ok(message);
     }
 
+    public ResponseEntity<String> addFeedbackToDocument(String id, int feedback, String authToken)
+            throws InvalidAuthenticationTokenException {
+        if (!authToken.equals(authtoken)) {
+            throw new InvalidAuthenticationTokenException();
+        }
+
+        String message = "Could not add feedback to task. Reason: Feedback must be a number between 0 and 10 inclusive";
+
+        if (feedback < 0 || feedback > 10) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(message);
+        }
+
+        message = "Could not add feedback to task. Reason: Task with ID '" + id + "' does not exist";
+
+        TaskEntity documentToAddFeedback = taskRepository.findById(id).orElse(null);
+
+        if (documentToAddFeedback == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(message);
+        }
+
+        message = "Could not add feedback to task. Reason: Task with ID '" + id + "' is not completed yet";
+
+        if (!documentToAddFeedback.isDone()) {
+            return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).body(message);
+        }
+
+        documentToAddFeedback.setFeedback(feedback);
+
+        taskRepository.deleteById(id);
+        taskRepository.save(documentToAddFeedback);
+
+        message = "Feedback successfully added to task";
+        return ResponseEntity.ok(message);
+    }
+
     public ResponseEntity<String> deleteDocument(String id, String authToken) throws InvalidAuthenticationTokenException {
         if (!authToken.equals(authtoken)) {
             throw new InvalidAuthenticationTokenException();

--- a/src/main/java/de/janetschel/haushaltsplan/backend/service/TaskService.java
+++ b/src/main/java/de/janetschel/haushaltsplan/backend/service/TaskService.java
@@ -73,6 +73,7 @@ public class TaskService {
         documentToUpdate.setPic(taskEntity.getPic());
         documentToUpdate.setBlame(taskEntity.getBlame());
         documentToUpdate.setDone(taskEntity.isDone());
+        documentToUpdate.setFeedback(taskEntity.getFeedback());
 
         taskRepository.deleteById(id);
         taskRepository.save(documentToUpdate);

--- a/src/test/java/de/janetschel/haushaltsplan/backend/controller/AuthTokenControllerTest.java
+++ b/src/test/java/de/janetschel/haushaltsplan/backend/controller/AuthTokenControllerTest.java
@@ -3,6 +3,7 @@ package de.janetschel.haushaltsplan.backend.controller;
 import de.janetschel.haushaltsplan.backend.exception.InvalidBase64StringException;
 import de.janetschel.haushaltsplan.backend.service.AuthTokenService;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +24,7 @@ public class AuthTokenControllerTest {
     private AuthTokenService authTokenService;
 
     @Test
+    @DisplayName("/getAuthtoken -> 200 OK")
     public void givenValidHeader_whenGetAuthToken_thenValidAuthtoken_andStatus200() throws Exception {
         String authorization = "samplestring";
         Mockito.when(authTokenService.getAuthToken(authorization)).thenReturn(ResponseEntity.ok("authtoken"));
@@ -35,6 +37,7 @@ public class AuthTokenControllerTest {
     }
 
     @Test
+    @DisplayName("/getAuthtoken invalid credentials -> 403 FORBIDDEN")
     public void givenInvalidHeader_whenGetAuthToken_thenStatus403() throws Exception {
         String authorization = "wrongsamplestring";
         Mockito.when(authTokenService.getAuthToken(authorization)).thenThrow(InvalidBase64StringException.class);
@@ -43,16 +46,5 @@ public class AuthTokenControllerTest {
                 .andDo(MockMvcResultHandlers.print()).andExpect(MockMvcResultMatchers.status().isForbidden());
 
         Mockito.verify(authTokenService, Mockito.times(1)).getAuthToken(authorization);
-    }
-
-    @Test
-    public void givenNoHeader_whenGetAuthToken_thenStatus400() throws Exception {
-        String authorization = "samplestring";
-        Mockito.when(authTokenService.getAuthToken(authorization)).thenReturn(ResponseEntity.ok("authtoken"));
-
-        this.mockMvc.perform(MockMvcRequestBuilders.get("/getAuthToken"))
-                .andDo(MockMvcResultHandlers.print()).andExpect(MockMvcResultMatchers.status().isBadRequest());
-
-        Mockito.verify(authTokenService, Mockito.never()).getAuthToken(authorization);
     }
 }

--- a/src/test/java/de/janetschel/haushaltsplan/backend/controller/HealthCheckControllerTest.java
+++ b/src/test/java/de/janetschel/haushaltsplan/backend/controller/HealthCheckControllerTest.java
@@ -2,6 +2,7 @@ package de.janetschel.haushaltsplan.backend.controller;
 
 import de.janetschel.haushaltsplan.backend.service.HealthCheckService;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,7 @@ public class HealthCheckControllerTest {
     private HealthCheckService healthCheckService;
 
     @Test
+    @DisplayName("/healthcheck -> 200 OK")
     public void whenHealthcheck_thenOkMessage_andStatus200() throws Exception {
         Mockito.when(healthCheckService.healthCheck()).thenReturn(ResponseEntity.ok("Healthcheck ok"));
 

--- a/src/test/java/de/janetschel/haushaltsplan/backend/controller/LoginControllerTest.java
+++ b/src/test/java/de/janetschel/haushaltsplan/backend/controller/LoginControllerTest.java
@@ -1,6 +1,7 @@
 package de.janetschel.haushaltsplan.backend.controller;
 
 import de.janetschel.haushaltsplan.backend.service.LoginService;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,7 @@ public class LoginControllerTest {
     private LoginService loginService;
 
     @Test
+    @DisplayName("/login -> 200 OK")
     public void givenValidHeader_whenLoginUser_thenTrue_andStatus200() throws Exception {
         String authorization = "samplestring";
         Mockito.when(loginService.loginUser(authorization)).thenReturn(ResponseEntity.ok(true));
@@ -34,6 +36,7 @@ public class LoginControllerTest {
     }
 
     @Test
+    @DisplayName("/login invalid credentials -> 403 FORBIDDEN")
     public void givenInvalidHeader_whenLoginUser_thenFalse_andStatus403() throws Exception {
         String authorization = "wrongsamplestring";
         Mockito.when(loginService.loginUser(authorization)).thenReturn(ResponseEntity.status(HttpStatus.FORBIDDEN).body(false));
@@ -43,16 +46,5 @@ public class LoginControllerTest {
                 .andExpect(MockMvcResultMatchers.content().string("false"));
 
         Mockito.verify(loginService, Mockito.times(1)).loginUser(authorization);
-    }
-
-    @Test
-    public void givenNoHeader_whenLoginUser_thenStatus400() throws Exception {
-        String authorization = "samplestring";
-        Mockito.when(loginService.loginUser(authorization)).thenReturn(ResponseEntity.ok(true));
-
-        this.mockMvc.perform(MockMvcRequestBuilders.get("/login"))
-                .andDo(MockMvcResultHandlers.print()).andExpect(MockMvcResultMatchers.status().isBadRequest());
-
-        Mockito.verify(loginService, Mockito.never()).loginUser(authorization);
     }
 }

--- a/src/test/java/de/janetschel/haushaltsplan/backend/controller/TaskControllerTest.java
+++ b/src/test/java/de/janetschel/haushaltsplan/backend/controller/TaskControllerTest.java
@@ -3,6 +3,7 @@ package de.janetschel.haushaltsplan.backend.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.janetschel.haushaltsplan.backend.entity.TaskEntity;
+import de.janetschel.haushaltsplan.backend.enums.Feedback;
 import de.janetschel.haushaltsplan.backend.exception.InvalidAuthenticationTokenException;
 import de.janetschel.haushaltsplan.backend.service.TaskService;
 import org.hamcrest.Matchers;
@@ -34,7 +35,7 @@ public class TaskControllerTest {
 
     @BeforeEach
     public void setupTests() {
-        taskEntity = new TaskEntity("id", "monday", "Kochen", "Jan", "Jan", false, -1);
+        taskEntity = new TaskEntity("id", "monday", "Kochen", "Jan", "Jan", false, Feedback.GOOD);
         id = "id";
     }
 

--- a/src/test/java/de/janetschel/haushaltsplan/backend/controller/TaskControllerTest.java
+++ b/src/test/java/de/janetschel/haushaltsplan/backend/controller/TaskControllerTest.java
@@ -34,7 +34,7 @@ public class TaskControllerTest {
 
     @BeforeEach
     public void setupTests() {
-        taskEntity = new TaskEntity("id", "monday", "Kochen", "Jan", "Jan", false);
+        taskEntity = new TaskEntity("id", "monday", "Kochen", "Jan", "Jan", false, -1);
         id = "id";
     }
 

--- a/src/test/java/de/janetschel/haushaltsplan/backend/controller/TaskControllerTest.java
+++ b/src/test/java/de/janetschel/haushaltsplan/backend/controller/TaskControllerTest.java
@@ -42,6 +42,7 @@ public class TaskControllerTest {
     }
 
     @Test
+    @DisplayName("/getDocuments -> 200 OK")
     public void givenValidHeader_whenGetDocuments_thenListOfDocuments_andStatus200() throws Exception {
         String authtoken = "authtoken";
         Mockito.when(taskService.getDocuments(authtoken)).thenReturn(ResponseEntity.ok(Collections.singletonList(taskEntity)));
@@ -54,6 +55,7 @@ public class TaskControllerTest {
     }
 
     @Test
+    @DisplayName("/getDocuments invalid credentials -> 403 FORBIDDEN")
     public void givenInvalidHeader_whenGetDocuments_thenStatus403() throws Exception {
         String authtoken = "wrongauthtoken";
         Mockito.when(taskService.getDocuments(authtoken)).thenThrow(InvalidAuthenticationTokenException.class);
@@ -65,17 +67,7 @@ public class TaskControllerTest {
     }
 
     @Test
-    public void givenNoHeader_whenGetDocuments_thenStatus400() throws Exception {
-        String authtoken = "authtoken";
-        Mockito.when(taskService.getDocuments(authtoken)).thenReturn(ResponseEntity.ok(Collections.singletonList(taskEntity)));
-
-        this.mockMvc.perform(MockMvcRequestBuilders.get("/getDocuments"))
-                .andDo(MockMvcResultHandlers.print()).andExpect(MockMvcResultMatchers.status().isBadRequest());
-
-        Mockito.verify(taskService, Mockito.never()).getDocuments(authtoken);
-    }
-
-    @Test
+    @DisplayName("/addDocument -> 200 OK")
     public void givenValidHeader_whenAddDocument_thenSuccessfulMessage_andStatus200() throws Exception {
         String authtoken = "authtoken";
         Mockito.when(taskService.addDocument(taskEntity, authtoken)).thenReturn(ResponseEntity.ok("Update successful"));
@@ -90,6 +82,7 @@ public class TaskControllerTest {
     }
 
     @Test
+    @DisplayName("/addDocument invalid credentials -> 403 FORBIDDEN")
     public void givenInvalidHeader_whenAddDocument_thenStatus403() throws Exception {
         String authtoken = "wrongauthtoken";
         Mockito.when(taskService.addDocument(taskEntity, authtoken)).thenThrow(InvalidAuthenticationTokenException.class);
@@ -103,18 +96,7 @@ public class TaskControllerTest {
     }
 
     @Test
-    public void givenNoHeader_whenAddDocument_thenSuccessfulMessage_andStatus400() throws Exception {
-        String authtoken = "authtoken";
-        Mockito.when(taskService.addDocument(taskEntity, authtoken)).thenReturn(ResponseEntity.ok("Update successful"));
-
-        this.mockMvc.perform(MockMvcRequestBuilders
-                    .post("/addDocument").contentType(MediaType.APPLICATION_JSON).content(taskEntityAsJson(taskEntity)))
-                .andDo(MockMvcResultHandlers.print()).andExpect(MockMvcResultMatchers.status().isBadRequest());
-
-        Mockito.verify(taskService, Mockito.never()).addDocument(taskEntity, authtoken);
-    }
-
-    @Test
+    @DisplayName("/addDocument no/invalid body -> 400 BAD_REQUEST")
     public void givenNoBody_whenAddDocument_thenStatus400() throws Exception {
         String authtoken = "authtoken";
         Mockito.when(taskService.addDocument(taskEntity, authtoken)).thenReturn(ResponseEntity.ok("Update successful"));
@@ -126,6 +108,7 @@ public class TaskControllerTest {
     }
 
     @Test
+    @DisplayName("/updateDocument -> 200 OK")
     public void givenValidHeader_whenUpdateDocument_thenSuccessfulMessage_andStatus200() throws Exception {
         String authtoken = "authtoken";
         Mockito.when(taskService.updateDocument(taskEntity, authtoken)).thenReturn(ResponseEntity.ok("Update successful"));
@@ -140,6 +123,7 @@ public class TaskControllerTest {
     }
 
     @Test
+    @DisplayName("/updateDocument invalid credentials -> 403 FORBIDDEN")
     public void givenInvalidHeader_whenUpdateDocument_thenStatus403() throws Exception {
         String authtoken = "wrongauthtoken";
         Mockito.when(taskService.updateDocument(taskEntity, authtoken)).thenThrow(InvalidAuthenticationTokenException.class);
@@ -153,18 +137,7 @@ public class TaskControllerTest {
     }
 
     @Test
-    public void givenNoHeader_whenUpdateDocument_thenStatus400() throws Exception {
-        String authtoken = "authtoken";
-        Mockito.when(taskService.updateDocument(taskEntity, authtoken)).thenReturn(ResponseEntity.ok("Update successful"));
-
-        this.mockMvc.perform(MockMvcRequestBuilders
-                .put("/updateDocument").contentType(MediaType.APPLICATION_JSON).content(taskEntityAsJson(taskEntity)))
-                .andDo(MockMvcResultHandlers.print()).andExpect(MockMvcResultMatchers.status().isBadRequest());
-
-        Mockito.verify(taskService, Mockito.never()).updateDocument(taskEntity, authtoken);
-    }
-
-    @Test
+    @DisplayName("/updateDocument no/indalid body -> 400 BAD_REQUEST")
     public void givenNoBody_whenUpdateDocument_thenStatus400() throws Exception {
         String authtoken = "authtoken";
         Mockito.when(taskService.updateDocument(taskEntity, authtoken)).thenReturn(ResponseEntity.ok("Update successful"));
@@ -176,6 +149,7 @@ public class TaskControllerTest {
     }
 
     @Test
+    @DisplayName("/updateDocument/addFeedback -> 200 OK")
     public void givenValidHeader_whenAddFeedbackToDocument_thenStatus200() throws Exception {
         String authtoken = "wrongauthtoken";
         Mockito.when(taskService.addFeedbackToDocument(taskEntity.getId(), taskEntity.getFeedback(), authtoken))
@@ -193,6 +167,7 @@ public class TaskControllerTest {
     }
 
     @Test
+    @DisplayName("/updateDocument/addFeedback invalid header -> 403 FORBIDDEN")
     public void givenInvalidHeader_whenAddFeedbackToDocument_thenStatus403() throws Exception {
         String authtoken = "wrongauthtoken";
         Mockito.when(taskService.addFeedbackToDocument(taskEntity.getId(), taskEntity.getFeedback(), authtoken))
@@ -209,20 +184,7 @@ public class TaskControllerTest {
     }
 
     @Test
-    public void givenNoHeader_whenAddFeedbackToDocument_thenStatus400() throws Exception {
-        String authtoken = "authtoken";
-        Mockito.when(taskService.addFeedbackToDocument(taskEntity.getId(), taskEntity.getFeedback(), authtoken))
-                .thenReturn(ResponseEntity.ok("Added feedback successfully"));
-
-        this.mockMvc.perform(MockMvcRequestBuilders
-                    .put("/updateDocument/addFeedback/id")
-                    .param("feedback", taskEntity.getFeedback().getValue()))
-                .andDo(MockMvcResultHandlers.print()).andExpect(MockMvcResultMatchers.status().isBadRequest());
-
-        Mockito.verify(taskService, Mockito.never()).addFeedbackToDocument(taskEntity.getId(), taskEntity.getFeedback(), authtoken);
-    }
-
-    @Test
+    @DisplayName("/updateDocument/addFeedback not existing id -> 404 NOT_FOUND")
     public void givenNotExistingId_whenAddFeedbackToDocument_thenStatus404() throws Exception {
         String authtoken = "wrongauthtoken";
         Mockito.when(taskService.addFeedbackToDocument(taskEntity.getId(), taskEntity.getFeedback(), authtoken))
@@ -240,7 +202,8 @@ public class TaskControllerTest {
     }
 
     @Test
-    public void givenInvalidId_whenAddFeedbackToDocument_thenStatus404() throws Exception {
+    @DisplayName("/updateDocument/addFeedback invalid id -> 406 NOT_ACCEPTABLE")
+    public void givenInvalidId_whenAddFeedbackToDocument_thenStatus406() throws Exception {
         String authtoken = "wrongauthtoken";
         Mockito.when(taskService.addFeedbackToDocument(taskEntity.getId(), taskEntity.getFeedback(), authtoken))
                 .thenReturn(ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).body("Task is not done"));
@@ -257,6 +220,7 @@ public class TaskControllerTest {
     }
 
     @Test
+    @DisplayName("/deleteDocument -> 200 OK")
     public void givenValidHeader_whenDeleteDocument_thenSuccessfulMessage_andStatus200() throws Exception {
         String authtoken = "authtoken";
         Mockito.when(taskService.deleteDocument(id, authtoken)).thenReturn(ResponseEntity.ok("Delete performed successfully"));
@@ -271,6 +235,7 @@ public class TaskControllerTest {
     }
 
     @Test
+    @DisplayName("/deleteDocument invalid credentials -> 403 FORBIDDEN")
     public void givenInvalidHeader_whenDeleteDocument_thenStatus403() throws Exception {
         String authtoken = "wrongauthtoken";
         Mockito.when(taskService.deleteDocument(id, authtoken)).thenThrow(InvalidAuthenticationTokenException.class);
@@ -281,29 +246,6 @@ public class TaskControllerTest {
                 .andDo(MockMvcResultHandlers.print()).andExpect(MockMvcResultMatchers.status().isForbidden());
 
         Mockito.verify(taskService, Mockito.times(1)).deleteDocument(id, authtoken);
-    }
-
-    @Test
-    public void givenNoHeader_whenDeleteDocument_thenStatus400() throws Exception {
-        String authtoken = "authtoken";
-        Mockito.when(taskService.deleteDocument(id, authtoken)).thenReturn(ResponseEntity.ok("Delete performed successfully"));
-
-        this.mockMvc.perform(MockMvcRequestBuilders
-                    .delete("/deleteDocument").param("id", id))
-                .andDo(MockMvcResultHandlers.print()).andExpect(MockMvcResultMatchers.status().isBadRequest());
-
-        Mockito.verify(taskService, Mockito.never()).deleteDocument(id, authtoken);
-    }
-
-    @Test
-    public void givenNoIdAsRequestParam_whenDeleteDocument_thenStatus400() throws Exception {
-        String authtoken = "authtoken";
-        Mockito.when(taskService.deleteDocument(id, authtoken)).thenReturn(ResponseEntity.ok("Delete performed successfully"));
-
-        this.mockMvc.perform(MockMvcRequestBuilders.delete("/deleteDocument").header("Auth-Token", authtoken))
-                .andDo(MockMvcResultHandlers.print()).andExpect(MockMvcResultMatchers.status().isBadRequest());
-
-        Mockito.verify(taskService, Mockito.never()).deleteDocument(id, authtoken);
     }
 
     private String taskEntityAsJson(TaskEntity taskEntity) {

--- a/src/test/java/de/janetschel/haushaltsplan/backend/service/TaskServiceTest.java
+++ b/src/test/java/de/janetschel/haushaltsplan/backend/service/TaskServiceTest.java
@@ -1,6 +1,7 @@
 package de.janetschel.haushaltsplan.backend.service;
 
 import de.janetschel.haushaltsplan.backend.entity.TaskEntity;
+import de.janetschel.haushaltsplan.backend.enums.Feedback;
 import de.janetschel.haushaltsplan.backend.exception.InvalidAuthenticationTokenException;
 import de.janetschel.haushaltsplan.backend.repository.TaskRepository;
 import lombok.SneakyThrows;
@@ -36,7 +37,7 @@ public class TaskServiceTest {
     @Before
     public void setupTests() {
         ReflectionTestUtils.setField(taskService, "authtoken", authtoken);
-        taskEntity = new TaskEntity("1", "monday", "Kochen", "Jan", "Jan", false, -1);
+        taskEntity = new TaskEntity("1", "monday", "Kochen", "Jan", "Jan", false, Feedback.GOOD);
     }
 
     @Test

--- a/src/test/java/de/janetschel/haushaltsplan/backend/service/TaskServiceTest.java
+++ b/src/test/java/de/janetschel/haushaltsplan/backend/service/TaskServiceTest.java
@@ -36,7 +36,7 @@ public class TaskServiceTest {
     @Before
     public void setupTests() {
         ReflectionTestUtils.setField(taskService, "authtoken", authtoken);
-        taskEntity = new TaskEntity("1", "monday", "Kochen", "Jan", "Jan", false);
+        taskEntity = new TaskEntity("1", "monday", "Kochen", "Jan", "Jan", false, -1);
     }
 
     @Test

--- a/src/test/java/de/janetschel/haushaltsplan/backend/service/TaskServiceTest.java
+++ b/src/test/java/de/janetschel/haushaltsplan/backend/service/TaskServiceTest.java
@@ -8,6 +8,7 @@ import lombok.SneakyThrows;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -42,7 +43,7 @@ public class TaskServiceTest {
 
     @Test
     @SneakyThrows(InvalidAuthenticationTokenException.class)
-    public void givenValidAuthtoken_whenGetDocument_thenNoException() {
+    public void givenValidAuthtoken_whenGetDocuments_thenNoException() {
         List<TaskEntity> expectedTaskEntities = Collections.singletonList(new TaskEntity());
         Mockito.when(taskRepository.findAll()).thenReturn(expectedTaskEntities);
 
@@ -58,7 +59,7 @@ public class TaskServiceTest {
 
     @Test(expected = InvalidAuthenticationTokenException.class)
     @SneakyThrows(InvalidAuthenticationTokenException.class)
-    public void givenInvalidAuthtoken_whenGetDocument_thenInvalidAuthenticationTokenException() {
+    public void givenInvalidAuthtoken_whenGetDocuments_thenInvalidAuthenticationTokenException() {
         taskService.getDocuments("totally_wrong_authtoken");
     }
 


### PR DESCRIPTION
If a task is complete feedback can be added to it (plan is that in the frontend only the person who is not in charge of completing the task can give feedback).

Validity of feedback values is controlled via the Feedback enum. Every task is assigned the value `Feedback.NO_FEEDBACK_GIVEN` by default and when not completed.
Feedbacks can be: `GOOD`, `OKAY` and `BAD`.

Testing is implemented both for the controller and for the service part

For this to work the entity needs an extra field `private Feedback feedback`